### PR TITLE
use github logo for github link in the footer

### DIFF
--- a/devkit.html
+++ b/devkit.html
@@ -212,7 +212,7 @@
         </li-->
 			<li>
 				<a class="hover:underline flex justify-start" href="https://github.com/spr-networks/super/">
-					<div class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/discord.svg)] dark:invert dark:opacity-70"></div>
+					<div class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/github.svg)] dark:invert dark:opacity-70"></div>
 					<div class="inline-flex align-self-center">github</div>
 				</a>
 			</li>

--- a/index.html
+++ b/index.html
@@ -785,7 +785,7 @@
             href="https://github.com/spr-networks/super/"
           >
             <div
-              class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/discord.svg)] dark:invert dark:opacity-70"
+              class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/github.svg)] dark:invert dark:opacity-70"
             ></div>
             <div class="inline-flex align-self-center">github</div>
           </a>

--- a/output.css
+++ b/output.css
@@ -1113,6 +1113,9 @@ Ensure the default browser behavior of the `hidden` attribute.
 .bg-\[url\(\/assets\/img\/discord\.svg\)\] {
   background-image: url(/assets/img/discord.svg);
 }
+.bg-\[url\(\/assets\/img\/github\.svg\)\] {
+  background-image: url(/assets/img/github.svg);
+}
 
 .bg-\[url\(\/assets\/img\/twitter\.svg\)\] {
   background-image: url(/assets/img/twitter.svg);

--- a/plus.html
+++ b/plus.html
@@ -1000,7 +1000,7 @@
             href="https://github.com/spr-networks/super/"
           >
             <div
-              class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/discord.svg)] dark:invert dark:opacity-70"
+              class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/github.svg)] dark:invert dark:opacity-70"
             ></div>
             <div class="inline-flex align-self-center">github</div>
           </a>

--- a/wifiturtles-jan.html
+++ b/wifiturtles-jan.html
@@ -231,7 +231,7 @@
         </li-->
 			<li>
 				<a class="hover:underline flex justify-start" href="https://github.com/spr-networks/super/">
-					<div class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/discord.svg)] dark:invert dark:opacity-70"></div>
+					<div class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/github.svg)] dark:invert dark:opacity-70"></div>
 					<div class="inline-flex align-self-center">github</div>
 				</a>
 			</li>

--- a/wifiturtles.html
+++ b/wifiturtles.html
@@ -235,7 +235,7 @@
         </li-->
 			<li>
 				<a class="hover:underline flex justify-start" href="https://github.com/spr-networks/super/">
-					<div class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/discord.svg)] dark:invert dark:opacity-70"></div>
+					<div class="inline-flex w-5 h-5 pl-6 bg-no-repeat bg-[url(/assets/img/github.svg)] dark:invert dark:opacity-70"></div>
 					<div class="inline-flex align-self-center">github</div>
 				</a>
 			</li>


### PR DESCRIPTION
A really minor issue, but the site is using the Discord logo for both the Discord and Github links in the footer, even though there already is a GitHub logo in the assets.

Note that this PR contains a trivial, but manual change to `output.css`.